### PR TITLE
Added set/clear/get methods for optionsets in dialog

### DIFF
--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/ModalDialog.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/Elements/ModalDialog.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="control"></param>
         public void ClearValue(OptionSet control)
         {
-            _client.ClearValue(control);
+            _client.ClearDialogValue(control);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="option">The option you want to set.</param>
         public string GetValue(OptionSet field)
         {
-            return _client.GetValue(field);
+            return _client.GetDialogValue(field);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
         /// <param name="option">The option you want to set.</param>
         public void SetValue(OptionSet optionSet)
         {
-            _client.SetValue(optionSet);
+            _client.SetDialogValue(optionSet);
         }
 
         /// <summary>

--- a/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
+++ b/Microsoft.Dynamics365.UIAutomation.Api.UCI/WebClient.cs
@@ -1872,8 +1872,7 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             {
 
                 var XPath =  AppElements.Xpath[AppReference.Entity.TextFieldContainer].Replace("[NAME]", field);
-                //XPath = "//section[contains(@id,'DialogContainer')]" + XPath;
-
+                
                 var fieldContainer = driver.WaitUntilAvailable(By.XPath(XPath));
 
                 IWebElement input;
@@ -2051,6 +2050,25 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
 
             var selectedItem = items.ElementAt(index);
             selectedItem.Click(true);
+        }
+
+        /// <summary>
+        /// Sets the value of a picklist or status field.
+        /// </summary>
+        /// <param name="control">The option you want to set.</param>
+        /// <example>xrmApp.Entity.SetValue(new OptionSet { Name = "preferredcontactmethodcode", Value = "Email" });</example>
+        public BrowserCommandResult<bool> SetDialogValue(OptionSet control)
+        {
+            var controlName = control.Name;
+            return Execute(GetOptions($"Set OptionSet Value: {controlName}"), driver =>
+            {
+                var dialogXPath = AppElements.Xpath[AppReference.Entity.OptionSetFieldContainer].Replace("[NAME]", controlName);
+                dialogXPath = "//section[contains(@id,'DialogContainer')]" + dialogXPath;
+
+                var fieldContainer = driver.WaitUntilAvailable(By.XPath(dialogXPath));
+                TrySetValue(fieldContainer, control);
+                return true;
+            });
         }
 
         /// <summary>
@@ -2557,6 +2575,25 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
             }
 
             throw new InvalidOperationException($"Field: {controlName} Does not exist", ex);
+        }
+
+        /// <summary>
+        /// Gets the value of a picklist or status field.
+        /// </summary>
+        /// <param name="control">The option you want to set.</param>
+        /// <example>xrmApp.Entity.GetValue(new OptionSet { Name = "preferredcontactmethodcode"}); </example>
+        internal BrowserCommandResult<string> GetDialogValue(OptionSet control)
+        {
+            var controlName = control.Name;
+            return this.Execute($"Get OptionSet Value: {controlName}", driver =>
+            {
+                var xpathToFieldContainer = AppElements.Xpath[AppReference.Entity.OptionSetFieldContainer].Replace("[NAME]", controlName);
+                xpathToFieldContainer = "//section[contains(@id,'DialogContainer')]" + xpathToFieldContainer;
+
+                var fieldContainer = driver.WaitUntilAvailable(By.XPath(xpathToFieldContainer));
+                string result = TryGetValue(fieldContainer, control);
+                return result;
+            });
         }
 
         /// <summary>
@@ -3174,6 +3211,17 @@ namespace Microsoft.Dynamics365.UIAutomation.Api.UCI
                 throw new InvalidOperationException($"Field '{controlName}' does not contain a record with the name:  {value}");
 
             existingValue.Click(true);
+        }
+
+        internal BrowserCommandResult<bool> ClearDialogValue(OptionSet control)
+        {
+            return this.Execute(GetOptions($"Clear Field {control.Name}"), driver =>
+            {
+                control.Value = "-1";
+                SetDialogValue(control);
+
+                return true;
+            });
         }
 
         internal BrowserCommandResult<bool> ClearValue(OptionSet control)


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (updates to documentation, formatting, etc.)

### Description
<!--- Describe your changes -->

### Issues addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### All submissions:

- [ ] My code follows the code style of this project.
- [ ] Do existing samples that are effected by this change still run?
- [ ] I have added samples for new functionality. 
- [ ] I raise detailed error messages when possible.
- [ ] My code does not rely on labels that have the option to be hidden.

### Which browsers was this tested on?
<!--- Should be tested on Chrome, Firefox, and IE. -->
- [ ] Chrome
- [ ] Firefox
- [ ] IE
- [ ] Edge
